### PR TITLE
Handle passing auto_merge to github-deploy

### DIFF
--- a/github-deploy/README.md
+++ b/github-deploy/README.md
@@ -4,4 +4,5 @@
            github_app_private_key: ${{ secrets.GITHUB_DEPLOY_APP_PRIVATE_KEY }}
            deploy_environment: production
            deploy_ref: master #optional will be current ref otherwise
+           auto_merge: false #optional and defaults to true
 ```

--- a/github-deploy/action.yml
+++ b/github-deploy/action.yml
@@ -1,16 +1,16 @@
-name: 'Trigger Github Deploy Event'
-description: 'triggers a github event using github actions, cirvumvents the $GITHUB_TOKEN limitations'
-author: 'Pierre-Alexandre St-Jean'
+name: "Trigger Github Deploy Event"
+description: "triggers a github event using github actions, cirvumvents the $GITHUB_TOKEN limitations"
+author: "Pierre-Alexandre St-Jean"
 inputs:
   github_app_private_key:
     description: The RSA private key associated with the github_app_id app
     required: true
   github_app_id:
     required: true
-    default: '32215'
+    default: "32215"
   github_app_installation_id:
     required: true
-    default: '1105541'
+    default: "1105541"
 
   deploy_repository:
     description: The repository to trigger a deploy event on \"{owner}/{repo}\" defaults to `$GITHUB_REPOSITORY`
@@ -21,7 +21,10 @@ inputs:
   deploy_environment:
     required: true
     default: staging
+  auto_merge:
+    required: false
+    default: "true"
 
 runs:
-  using: 'node12'
-  main: 'lib/main.js'
+  using: "node12"
+  main: "lib/main.js"

--- a/github-deploy/lib/main.js
+++ b/github-deploy/lib/main.js
@@ -50,13 +50,15 @@ function run() {
             process.env["GITHUB_REPOSITORY"] ||
             "";
         const [owner, repo] = ownerRepo.split("/");
+        const autoMerge = core.getInput("auto_merge") !== "false";
         console.log(`Triggering Deploy event on '${owner}/${repo}' @ref:'${ref}' in env '${environment}'`);
         yield octokit.repos.createDeployment({
             owner,
             repo,
             ref,
             environment,
-            required_contexts: []
+            required_contexts: [],
+            auto_merge: autoMerge
         });
     });
 }

--- a/github-deploy/src/main.ts
+++ b/github-deploy/src/main.ts
@@ -31,6 +31,7 @@ async function run() {
     process.env["GITHUB_REPOSITORY"] ||
     "";
   const [owner, repo] = ownerRepo.split("/");
+  const autoMerge = core.getInput("auto_merge") !== "false";
 
   console.log(
     `Triggering Deploy event on '${owner}/${repo}' @ref:'${ref}' in env '${environment}'`
@@ -41,7 +42,8 @@ async function run() {
     repo,
     ref,
     environment,
-    required_contexts: []
+    required_contexts: [],
+    auto_merge: autoMerge
   });
 }
 


### PR DESCRIPTION
- Adds possibility to override github's default value for `auto_merge`
- Is optional and defaults to `"true"`
- Need to pass `"false"` to prevent auto_merging the default branch