### PR TITLE
Fix PR comment

### DIFF
--- a/comment_pr_deploy_link/entrypoint.sh
+++ b/comment_pr_deploy_link/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | tr ".\\/+" "-")
-COMMENT="The app for PR is available at https://$SANITIZED_BRANCH_NAME.backoffice.staging.pleo.io"
+COMMENT="The app for PR is available at https://$SANITIZED_BRANCH_NAME.$PROJECT_NAME.staging.pleo.io"
 
 PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
 

--- a/comment_pr_deploy_link/entrypoint.sh
+++ b/comment_pr_deploy_link/entrypoint.sh
@@ -2,7 +2,8 @@
 set -e
 
 SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | tr ".\\/+" "-")
-COMMENT="The app for PR is available at https://$SANITIZED_BRANCH_NAME.$PROJECT_NAME.staging.pleo.io"
+SANITIZED_PROJECT_NAME=$(echo "$PROJECT_NAME" | tr ".\\/+" "-")
+COMMENT="The app for PR is available at https://$SANITIZED_BRANCH_NAME.$SANITIZED_PROJECT_NAME.staging.pleo.io"
 
 PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
 


### PR DESCRIPTION
This action is creating the comment for every PR with a link to the respective branch code.
(Link points to the `release-staging` bucket for the project).

It is used so far in the backoffice which is why it is hardcoded for the backoffice.
This PR adds the `PROJECT_NAME` info to the script so it can be used to make it generic.

Complementary [backoffice PR](https://github.com/pleo-io/backoffice/pull/391)
Complementary [turbocharger PR](https://github.com/pleo-io/turbocharger/pull/13)