### PR TITLE
backend-feature-branch name

### DIFF
--- a/sanitize-branch-for-dns/Dockerfile
+++ b/sanitize-branch-for-dns/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:alpine
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/sanitize-branch-for-dns/Makefile
+++ b/sanitize-branch-for-dns/Makefile
@@ -1,0 +1,18 @@
+include ../docker.mk
+include ../help.mk
+include ../shell.mk
+
+.PHONY: clean
+clean: ## Clean up after the build process.
+
+.PHONY: lint
+lint: shell-lint docker-lint ## Lint all of the files for this Action.
+
+.PHONY: build
+build: docker-build ## Build this Action.
+
+.PHONY: test
+test: ## Test the components of this Action.
+
+.PHONY: publish
+publish: docker-publish ## Publish this Action.

--- a/sanitize-branch-for-dns/README.md
+++ b/sanitize-branch-for-dns/README.md
@@ -1,0 +1,26 @@
+### Description
+
+Sanitize a branch name such that it can be included in a DNS. This is particularly geared for feature-branch deployments, where DNS entries are generated for all feature-branch deployments.
+
+### Usage
+
+```yaml
+- name: Set branch name
+  id: set_branch_name
+  uses: pleo-io/actions/sanitize-branch-for-dns@d5761200d4a09d1f722b3d473f7ebe143ec33368
+  env:
+    github_head_ref: ${{ github.event.pull_request.head.ref }}
+    github_ref: ${{ github.event.pull_request.ref }}
+
+- run: echo "${{ steps.set_branch_name.outputs.branch_name }}"
+```
+
+### Sanitization Rules
+
+* If `github_head_ref` is not empty, use this vars value to proceed with rules
+* If not, uuse `github_ref` and trim `/refs/heads/` prefix
+
+1. Replace all `_` with `-`
+2. Trim to 40 characters
+3. Lowercase all letters
+4. If last character is `-`, trim it

--- a/sanitize-branch-for-dns/action.yaml
+++ b/sanitize-branch-for-dns/action.yaml
@@ -1,0 +1,19 @@
+name: 'Sanitize branch name'
+author: 'Cole Bittel'
+description: 'Sanitize branch name for DNS creation'
+inputs:
+  github_head_ref:
+    description: 'env var generated from GitHub context (eg. `refs/head/feature/my-branch`)'
+    required: true
+  github_ref:
+    description: 'env var generated from GitHub context (eg. `feature/my-branch`)'
+    required: true
+outputs:
+  branch_name:
+    description: 'PR branch name (eg. `feature-my-branch`)'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.GITHUB_HEAD_REF }}
+    - ${{ inputs.GITHUB_REF }}

--- a/sanitize-branch-for-dns/entrypoint.sh
+++ b/sanitize-branch-for-dns/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+
+echo GITHUB_HEAD_REF=$GITHUB_HEAD_REF
+echo GITHUB_REF=$GITHUB_REF
+if [ -z "$GITHUB_HEAD_REF" ]
+then
+echo "\$GITHUB_HEAD_REF is empty"
+BN=${GITHUB_REF#"refs/heads/"}
+else
+echo "\$GITHUB_HEAD_REF is NOT empty"
+BN=$GITHUB_HEAD_REF
+fi
+
+
+# Trimming and replacing characters to make URL user friendly
+BN=$(echo "$BN" | tr '/_.' '-')
+BN=$(echo "$BN" | cut -c1-40)
+
+# Abort if can't create branch name, as safety precaution
+if [ -z "$BN" ]
+then
+echo "\$BN is empty"
+exit 1
+fi
+
+echo BN=$BN
+echo ::set-env name=branch_name::${BN}

--- a/sanitize-branch-for-dns/entrypoint.sh
+++ b/sanitize-branch-for-dns/entrypoint.sh
@@ -26,4 +26,4 @@ exit 1
 fi
 
 echo BN=$BN
-echo ::set-env name=branch_name::${BN}
+echo ::set-output name=branch_name::${BN}

--- a/sanitize-branch-for-dns/entrypoint.sh
+++ b/sanitize-branch-for-dns/entrypoint.sh
@@ -13,10 +13,17 @@ echo "\$GITHUB_HEAD_REF is NOT empty"
 BN=$GITHUB_HEAD_REF
 fi
 
-
 # Trimming and replacing characters to make URL user friendly
 BN=$(echo "$BN" | tr '/_.' '-')
 BN=$(echo "$BN" | cut -c1-40)
+
+# All uppercase to lowercase
+BN=$(echo "$BN" | tr '[A-Z]' '[a-z]')
+echo "lowercased = $BN"
+
+# If ends in dash, remove
+BN=${BN%%-}
+echo "suffix dashes removed = $BN"
 
 # Abort if can't create branch name, as safety precaution
 if [ -z "$BN" ]


### PR DESCRIPTION
### Description

Sanitize a branch name such that it can be included in a DNS. This is particularly geared for feature-branch deployments, where DNS entries are generated for all feature-branch deployments.

### Usage

```yaml
- name: Set branch name
  id: set_branch_name
  uses: pleo-io/actions/sanitize-branch-for-dns@d5761200d4a09d1f722b3d473f7ebe143ec33368
  env:
    github_head_ref: ${{ github.event.pull_request.head.ref }}
    github_ref: ${{ github.event.pull_request.ref }}

- run: echo "${{ steps.set_branch_name.outputs.branch_name }}"
```

### Sanitization Rules

* If `github_head_ref` is not empty, use this vars value to proceed with rules
* If not, uuse `github_ref` and trim `/refs/heads/` prefix

1. Replace all `_` with `-`
2. Trim to 40 characters
3. Lowercase all letters
4. If last character is `-`, trim it