### PR TITLE
Fix localise-create-task to extract text between tags

### DIFF
--- a/lokalise-create-task/lib/helpers.js
+++ b/lokalise-create-task/lib/helpers.js
@@ -1,8 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const getContext = (text) => {
-    const foundText = text.match(/<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->(\n| )*((.|\n)*)(\n| )*<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->/);
-    return foundText ? foundText[2] : "";
+    const foundText = text.match(/<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->((.|\n|\r|\t)*)<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->/);
+    return foundText ? foundText[1] : "";
 };
 const getClubhouseLink = (text) => {
     const clubhouseLink = text.match(/Clubhouse Story: (.*)/);

--- a/lokalise-create-task/src/helpers.ts
+++ b/lokalise-create-task/src/helpers.ts
@@ -1,8 +1,8 @@
 const getContext = (text: string): string => {
   const foundText = text.match(
-    /<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->(\n| )*((.|\n)*)(\n| )*<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->/
+    /<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->((.|\n|\r|\t)*)<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->/
   );
-  return foundText ? foundText[2] : "";
+  return foundText ? foundText[1] : "";
 };
 
 const getClubhouseLink = (text: string): string => {


### PR DESCRIPTION
Description from github comes with `/r` symbol
Example:
```
'<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->\r\n' +
    'This is the test for automatic localize flow, it was between tags\r\n' +
    '<!--- LOKALIZE CONTEXT FOR TRANSLATORS -->\r\n' +
```

That's why the fix