### PR TITLE
Do not convert to universal endpoints

### DIFF
--- a/lokalise-file-push/lib/main.js
+++ b/lokalise-file-push/lib/main.js
@@ -63,6 +63,8 @@ function uploadFiles({ lokalise, projectId, filePath, tags, locales, callback, }
                     filename,
                     lang_iso: lang,
                     tags,
+                    //@ts-ignore
+                    convert_placeholders: false,
                 });
                 let inteval = yield setInterval(() => __awaiter(this, void 0, void 0, function* () {
                     if (process.status === "finished") {

--- a/lokalise-file-push/src/main.ts
+++ b/lokalise-file-push/src/main.ts
@@ -59,6 +59,8 @@ async function uploadFiles({
         filename,
         lang_iso: lang,
         tags,
+        //@ts-ignore
+        convert_placeholders: false,
       });
 
       let inteval = await setInterval(async () => {


### PR DESCRIPTION
This is a fun thing :) 

When they (localise team) updated the nature for uploading the file (a month ago or two) from synchronous to asynchronous, it seems that they started to force "universal placeholders" 
https://app.lokalise.com/api2docs/curl/#transition-upload-a-file-post for `convert_placeholders` default is true

What is "universal placeholders" in localise? https://docs.lokalise.com/en/articles/1400511-lokalise-placeholders?_ga=2.233498966.914921203.1604996860-745483976.1583158151

It has some advantages (in the possible future to convert from one format to another) to use them, but at the moment, not for us, because translators just learned to correctly update ICU format for placeholder and these universal endpoints could only bring mess for placeholders at all :) 