### PR TITLE
repos now use main branch not master

### DIFF
--- a/trigger-workflow-dispatch/action.yaml
+++ b/trigger-workflow-dispatch/action.yaml
@@ -14,7 +14,7 @@ inputs:
   WORKFLOW_FILE_REF:
     description: 'The GitHub branch to source the WORKFLOW_DISPATCH_FILE_NAME from'
     required: false
-    default: 'refs/heads/master'
+    default: 'refs/heads/main'
   ALLOW_CHAINED_DEPLOYMENTS:
     description: 'Allow workflows to chain together. Eg. if you are deploying to staging, should it be allowed to trigger a production deployment on success?'
     required: false


### PR DESCRIPTION
With this version and release, workflows are triggered with on the `main` branch, not the `master` branch.